### PR TITLE
Adoption of batch persistence to workaround the overhead caused by the insertion of metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,10 @@
 		<jdt.version>3.3.0-v_771</jdt.version>
 		<eclipse.resources.version>3.7.100</eclipse.resources.version>
 		<eclipse.runtime.version>3.10.0-v20140318-2214</eclipse.runtime.version>
-		<jdt.ui.version>3.3.0-v20070607-0010</jdt.ui.version>
 		<github-api.version>1.62</github-api.version>
 		<slf4j.version>1.6.2</slf4j.version>
 		<maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
 		<maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
-		<jface.version>3.3.0-I20070606-0010</jface.version>
 
 	</properties>
 
@@ -95,19 +93,6 @@
 			<version>${eclipse.runtime.version}</version>
 		</dependency>
 	
-		<dependency>
-			<groupId>org.eclipse.jdt</groupId>
-			<artifactId>ui</artifactId>
-			<version>${jdt.ui.version}</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.eclipse</groupId>
-			<artifactId>jface</artifactId>
-			<version>${jface.version}</version>
-		</dependency>
-		
-		
 	</dependencies>
 
 	<build>

--- a/src/main/java/META-INF/metrics.xml
+++ b/src/main/java/META-INF/metrics.xml
@@ -3,4 +3,6 @@
 	<metric id="NOC">br.edu.ufba.softvis.visminer.metric.NOCMetric</metric>
 	<metric id="NOP">br.edu.ufba.softvis.visminer.metric.NOPMetric</metric>
 	<metric id="SLOC">br.edu.ufba.softvis.visminer.metric.SLOCMetric</metric>
+	<metric id="NOM">br.edu.ufba.softvis.visminer.metric.NOMMetric</metric>
+	<metric id="NOE">br.edu.ufba.softvis.visminer.metric.NOEMetric</metric>
 </metrics>

--- a/src/main/java/br/edu/ufba/softvis/visminer/analyzer/MetricCalculator.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/analyzer/MetricCalculator.java
@@ -147,6 +147,7 @@ public class MetricCalculator{
 		fileDao.setEntityManager(entityManager);
 
 		MetricPersistance persistence = new MetricPersistance(entityManager);
+		persistence.initBatchPersistence();
 		
 		Map<File, AST> repositoryFiles = new HashMap<File, AST>();
 		Map<File, AST> commitFiles = new HashMap<File, AST>();
@@ -221,6 +222,8 @@ public class MetricCalculator{
 			
 		}// end for(CommitDB commitDb : commitsDb)
 
+		
+		persistence.flushAllMetricValues();
 	}
 	
 	// Calculates all the selected metrics for a given commit.

--- a/src/main/java/br/edu/ufba/softvis/visminer/ast/TypeDeclaration.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/ast/TypeDeclaration.java
@@ -1,6 +1,5 @@
 package br.edu.ufba.softvis.visminer.ast;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class TypeDeclaration {
@@ -8,7 +7,7 @@ public class TypeDeclaration {
 	private int id;
 	private String name;
 	private boolean interfaceClass;
-	private List<MethodDeclaration> methods = new ArrayList<MethodDeclaration>();
+	private List<MethodDeclaration> methods;
 
 	/**
 	 * @return the id

--- a/src/main/java/br/edu/ufba/softvis/visminer/ast/generator/JavaASTGenerator.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/ast/generator/JavaASTGenerator.java
@@ -76,12 +76,14 @@ public class JavaASTGenerator {
 			
 		}
 		
-		if(typesDecl.size() > 0){
-			document.setTypesDeclarations(typesDecl);
-		}
-		
-		if(enumsDecl.size() > 0){
-			document.setEnumsDeclarations(enumsDecl);
+		if(root.types().size() > 0){
+			if(typesDecl.size() > 0){
+				document.setTypesDeclarations(typesDecl);
+			}
+			
+			if(enumsDecl.size() > 0){
+				document.setEnumsDeclarations(enumsDecl);
+			}
 		}
 		
 		AST ast = new AST();
@@ -97,15 +99,19 @@ public class JavaASTGenerator {
 		typeDecl.setInterfaceClass(type.isInterface());
 		typeDecl.setName(type.getName().getFullyQualifiedName());
 		
+		if(type.getMethods().length == 0){
+			return typeDecl;
+		}
+		
 		List<MethodDeclaration> methodsDecl = new ArrayList<MethodDeclaration>();
 		for(org.eclipse.jdt.core.dom.MethodDeclaration method : type.getMethods()){
-			
 			
 			MethodDeclaration methodDecl = new MethodDeclaration();
 			methodDecl.setName(method.getName().getFullyQualifiedName());
 			Block body = method.getBody();
 			methodDecl.setStatements(processBlock(body));
 			methodsDecl.add(methodDecl);
+			
 		}
 		
 		typeDecl.setMethods(methodsDecl);
@@ -117,6 +123,10 @@ public class JavaASTGenerator {
 		
 		br.edu.ufba.softvis.visminer.ast.EnumDeclaration enumDecl = new br.edu.ufba.softvis.visminer.ast.EnumDeclaration();
 		enumDecl.setName(enumType.getName().getFullyQualifiedName());
+		
+		if(enumType.enumConstants() == null){
+			return enumDecl;
+		}
 		
 		List<EnumConstantDeclaration> constsDecls = new ArrayList<EnumConstantDeclaration>();
 		for(Object elem : enumType.enumConstants()){

--- a/src/main/java/br/edu/ufba/softvis/visminer/constant/MetricUid.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/constant/MetricUid.java
@@ -9,7 +9,9 @@ public enum MetricUid {
 	CC(1),
 	SLOC(2),
 	NOC(3),
-	NOP(4);
+	NOP(4),
+	NOM(5),
+	NOE(6);
 	
 	private int id;
 	

--- a/src/main/java/br/edu/ufba/softvis/visminer/metric/CCMetric.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/metric/CCMetric.java
@@ -39,9 +39,22 @@ public class CCMetric implements IMetric{
 			}
 
 			for(TypeDeclaration type : ast.getDocument().getTypesDeclarations()){
-				for(MethodDeclaration method : type.getMethods()){
-					persistence.saveMetricValue(method.getId(), calculate(method));
+				
+				if(type.getMethods() == null){
+					break;
 				}
+				
+				int sumCC = 0;
+				int numMethods = type.getMethods().size();
+				
+				for(MethodDeclaration method : type.getMethods()){
+					int cc = calculate(method);
+					sumCC += cc;
+					persistence.postMetricValue(method.getId(), String.valueOf(cc));
+				}
+				System.out.println("Commit: "+commits.get(commits.size()-1).getName()+" file "+entry.getKey().getPath()+" vals "+sumCC+" "+numMethods);
+				float averageCC = sumCC / numMethods;
+				persistence.postMetricValue(type.getId(), String.valueOf(averageCC));
 			}
 
 		}
@@ -49,10 +62,10 @@ public class CCMetric implements IMetric{
 	}
 
 
-	private String calculate(MethodDeclaration method) {
+	private int calculate(MethodDeclaration method) {
 
 		if(method.getStatements() == null){
-			return "1";
+			return 1;
 		}
 
 		int cc = 1;
@@ -66,7 +79,7 @@ public class CCMetric implements IMetric{
 			}
 		}
 
-		return String.valueOf(cc);
+		return cc;
 	}
 
 }

--- a/src/main/java/br/edu/ufba/softvis/visminer/metric/NOEMetric.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/metric/NOEMetric.java
@@ -15,19 +15,18 @@ import br.edu.ufba.softvis.visminer.model.bean.File;
 import br.edu.ufba.softvis.visminer.persistence.MetricPersistance;
 
 @MetricAnnotation(
-		name = "Number of Classes",
-		description = "Number of Classes is a software metric used to measure the size of a computer program"+
-				" by counting the number of classes and interfaces",
-		acronym = "NOC",
+		name = "Number of Enums",
+		description = "Number of Enums is a software metric used to measure the size of a computer program"+
+				" by counting the number of enums",
+		acronym = "NOE",
 		type = MetricType.COMPLEX,
-		uid = MetricUid.NOC
+		uid = MetricUid.NOE
 	)
-public class NOCMetric implements IMetric{
+public class NOEMetric implements IMetric{
 
 	@Override
-	public void calculate(Map<File, AST> filesMap, List<Commit> commits,
-			MetricPersistance persistence) {
-
+	public void calculate(Map<File, AST> filesMap, List<Commit> commits, MetricPersistance persistence) {
+		
 		Map<Integer, Integer> packageCls = new HashMap<Integer, Integer>();
 		
 		for(Entry<File, AST> entry : filesMap.entrySet()){
@@ -42,11 +41,7 @@ public class NOCMetric implements IMetric{
 			int id, num = 0;
 
 			if(doc.getEnumsDeclarations() != null){
-				num += doc.getEnumsDeclarations().size();
-			}
-			
-			if(doc.getTypesDeclarations() != null){
-				num += doc.getTypesDeclarations().size();
+				num = doc.getEnumsDeclarations().size();
 			}
 			
 			if(doc.getPackageDeclaration() != null){
@@ -56,8 +51,7 @@ public class NOCMetric implements IMetric{
 			}
 			
 			if(packageCls.containsKey(id)){
-				int aux = packageCls.get(id);
-				packageCls.put(id, aux + num);
+				packageCls.put(id, packageCls.get(id) + num);
 			}else{
 				packageCls.put(id, num);
 			}

--- a/src/main/java/br/edu/ufba/softvis/visminer/metric/NOMMetric.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/metric/NOMMetric.java
@@ -1,0 +1,51 @@
+package br.edu.ufba.softvis.visminer.metric;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import br.edu.ufba.softvis.visminer.annotations.MetricAnnotation;
+import br.edu.ufba.softvis.visminer.ast.AST;
+import br.edu.ufba.softvis.visminer.ast.Document;
+import br.edu.ufba.softvis.visminer.ast.TypeDeclaration;
+import br.edu.ufba.softvis.visminer.constant.MetricType;
+import br.edu.ufba.softvis.visminer.constant.MetricUid;
+import br.edu.ufba.softvis.visminer.model.bean.Commit;
+import br.edu.ufba.softvis.visminer.model.bean.File;
+import br.edu.ufba.softvis.visminer.persistence.MetricPersistance;
+
+@MetricAnnotation(
+	name = "Number of Methods",
+	description = "Number of Methods is a software metric used to count the number of Methods per classes",
+	acronym = "NOM",
+	type = MetricType.SIMPLE,
+	uid = MetricUid.NOM
+)
+public class NOMMetric implements IMetric {
+
+	@Override
+	public void calculate(Map<File, AST> filesMap, List<Commit> commits, MetricPersistance persistence){
+
+		for(Entry<File, AST> entry : filesMap.entrySet()){
+
+			AST ast = entry.getValue();
+			
+			if(ast == null || ast.getDocument().getTypesDeclarations() == null){
+				continue;
+			}
+
+			Document doc = entry.getValue().getDocument();
+			for(TypeDeclaration type : doc.getTypesDeclarations()){
+				
+				int m = 0;
+				if(type.getMethods() != null){
+					m = type.getMethods().size();
+				}
+				persistence.postMetricValue(type.getId(), String.valueOf(m));
+			}
+			
+		}
+		
+	}
+
+}

--- a/src/main/java/br/edu/ufba/softvis/visminer/metric/NOPMetric.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/metric/NOPMetric.java
@@ -53,8 +53,7 @@ public class NOPMetric implements IMetric{
 		
 		
 		int val = packages.size() + 1;
-		persistence.saveMetricValue(project, String.valueOf(val));
-		
+		persistence.postMetricValue(project, String.valueOf(val));
 	}
 
 }

--- a/src/main/java/br/edu/ufba/softvis/visminer/metric/SLOCMetric.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/metric/SLOCMetric.java
@@ -37,7 +37,7 @@ public class SLOCMetric implements IMetric{
 			
 			AST ast = entry.getValue();
 			Document doc = new Document(ast.getSourceCode());
-			persistence.saveMetricValue(ast.getDocument().getId(), String.valueOf(doc.getNumberOfLines()));
+			persistence.postMetricValue(ast.getDocument().getId(), String.valueOf(doc.getNumberOfLines()));
 		}
 	}
 

--- a/src/main/java/br/edu/ufba/softvis/visminer/persistence/SaveAST.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/persistence/SaveAST.java
@@ -76,6 +76,10 @@ public class SaveAST {
 						fileDb, repositoryDb, docUnit);
 				type.setId(typeUnit.getId());
 				
+				if(type.getMethods() == null){
+					continue;
+				}
+				
 				for(MethodDeclaration method : type.getMethods()){
 					String methodUid = generateUid(repositoryDb.getUid(), typeUid, method.getName());
 					SoftwareUnitDB methodUnit = getSofwareUnitDB(methodUid, method.getName(), SoftwareUnitType.METHOD,
@@ -93,6 +97,10 @@ public class SaveAST {
 				SoftwareUnitDB enumUnit = getSofwareUnitDB(enumUid, enumDecl.getName(), SoftwareUnitType.ENUM, fileDb,
 						repositoryDb, docUnit);
 				enumDecl.setId(enumUnit.getId());
+				
+				if(enumDecl.getDeclarations() == null){
+					continue;
+				}
 				
 				for(EnumConstantDeclaration constDecl : enumDecl.getDeclarations()){
 					String constUid = generateUid(repositoryDb.getUid(), enumUid, constDecl.getName());


### PR DESCRIPTION
This issue is/was closely related to a constrain in EclipseLink which forces wrapping each insertion (and also, possibly, updates and deletes) within a transaction block.

Preliminary tests responded well, as to an overall lessening in the overhead (= lastest mining consuming 1/5 of the original runtime). More tests must be conducted to certify that the modifications don't produce data inconsistency.  