### PR TITLE
I created the MethodVisitor to process nested statements

### DIFF
--- a/src/main/java/br/edu/ufba/softvis/visminer/ast/MethodDeclaration.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/ast/MethodDeclaration.java
@@ -6,6 +6,8 @@ public class MethodDeclaration {
 
 	private int id;
 	private String name;
+	private String modifier;
+	private boolean isConstructor;
 	private List<Statement> statements;
 
 	public int getId() {
@@ -30,6 +32,22 @@ public class MethodDeclaration {
 
 	public void setStatements(List<Statement> statements) {
 		this.statements = statements;
+	}
+
+	public String getModifier() {
+		return modifier;
+	}
+
+	public void setModifier(String modifier) {
+		this.modifier = modifier;
+	}
+
+	public boolean isConstructor() {
+		return isConstructor;
+	}
+
+	public void setConstructor(boolean isConstructor) {
+		this.isConstructor = isConstructor;
 	}
 	
 }

--- a/src/main/java/br/edu/ufba/softvis/visminer/ast/generator/JavaASTGenerator.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/ast/generator/JavaASTGenerator.java
@@ -119,20 +119,28 @@ public class JavaASTGenerator {
 		}
 		
 		List<MethodDeclaration> methodsDecl = new ArrayList<MethodDeclaration>();
-		for(org.eclipse.jdt.core.dom.MethodDeclaration method : type.getMethods()){
-			
-			MethodDeclaration methodDecl = new MethodDeclaration();
-			methodDecl.setName(method.getName().getFullyQualifiedName());
-			Block body = method.getBody();
-			methodDecl.setStatements(processBlock(body));
-			methodsDecl.add(methodDecl);
-			
-		}
+		for(org.eclipse.jdt.core.dom.MethodDeclaration method : type.getMethods())
+			methodsDecl.add(processMethod(method));		
 		
 		typeDecl.setMethods(methodsDecl);
 		return typeDecl;
 		
 	}
+	
+	private static MethodDeclaration processMethod(org.eclipse.jdt.core.dom.MethodDeclaration method){
+		
+		MethodDeclaration methodDecl = new MethodDeclaration();
+		methodDecl.setName(method.getName().getFullyQualifiedName());
+		methodDecl.setConstructor(method.isConstructor());
+		ModifierKeyword modifier = ModifierKeyword.fromFlagValue(method.getModifiers());
+		if(modifier!=null)
+			methodDecl.setModifier(modifier.toString());			
+		
+		Block body = method.getBody();
+		methodDecl.setStatements(processBlock(body));
+		return methodDecl;
+	}
+	
 	
 	private static FieldDeclaration processField(org.eclipse.jdt.core.dom.FieldDeclaration field){
 				

--- a/src/main/java/br/edu/ufba/softvis/visminer/ast/generator/JavaASTGenerator.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/ast/generator/JavaASTGenerator.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
-
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.Block;
@@ -22,6 +21,7 @@ import br.edu.ufba.softvis.visminer.ast.FieldDeclaration;
 import br.edu.ufba.softvis.visminer.ast.PackageDeclaration;
 import br.edu.ufba.softvis.visminer.ast.Statement;
 import br.edu.ufba.softvis.visminer.constant.NodeType;
+import br.edu.ufba.softvis.visminer.visitor.MethodVisitor;
 
 public class JavaASTGenerator {
 
@@ -129,6 +129,9 @@ public class JavaASTGenerator {
 	
 	private static MethodDeclaration processMethod(org.eclipse.jdt.core.dom.MethodDeclaration method){
 		
+		MethodVisitor mVisitor = new MethodVisitor();
+		method.accept(mVisitor);	
+		
 		MethodDeclaration methodDecl = new MethodDeclaration();
 		methodDecl.setName(method.getName().getFullyQualifiedName());
 		methodDecl.setConstructor(method.isConstructor());
@@ -136,8 +139,8 @@ public class JavaASTGenerator {
 		if(modifier!=null)
 			methodDecl.setModifier(modifier.toString());			
 		
-		Block body = method.getBody();
-		methodDecl.setStatements(processBlock(body));
+		methodDecl.setStatements(mVisitor.getStatements());
+		
 		return methodDecl;
 	}
 	
@@ -176,34 +179,6 @@ public class JavaASTGenerator {
 		
 		enumDecl.setDeclarations(constsDecls);
 		return enumDecl;
-	}
-	
-	@SuppressWarnings("unchecked")
-	private static List<Statement> processBlock(Block body){
-		
-		if(body == null || body.statements() == null){
-			return null;
-		}
-
-		List<org.eclipse.jdt.core.dom.Statement> statements = body.statements();
-		List<Statement> statementsDecl = new ArrayList<Statement>(statements.size());
-		for(org.eclipse.jdt.core.dom.Statement statement : statements){
-
-			Statement statementDecl = new Statement();
-			switch(statement.getNodeType()){
-				case ASTNode.IF_STATEMENT: statementDecl.setNodeType(NodeType.IF); break;
-				case ASTNode.SWITCH_CASE: statementDecl.setNodeType(NodeType.SWITCH_CASE); break;
-				case ASTNode.FOR_STATEMENT:statementDecl.setNodeType(NodeType.FOR); break;
-				case ASTNode.DO_STATEMENT: statementDecl.setNodeType(NodeType.DO); break;
-				case ASTNode.WHILE_STATEMENT: statementDecl.setNodeType(NodeType.WHILE); break;
-				default : statementDecl.setNodeType(NodeType.NONE); break;
-			}
-			
-			statementsDecl.add(statementDecl);
-		}
-		
-		return statementsDecl;
-		
 	}
 	
 }

--- a/src/main/java/br/edu/ufba/softvis/visminer/constant/NodeType.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/constant/NodeType.java
@@ -2,6 +2,6 @@ package br.edu.ufba.softvis.visminer.constant;
 
 public enum NodeType {
 
-	NONE, IF, SWITCH_CASE, FOR, DO, WHILE;
+	NONE, IF, SWITCH_CASE, FOR, DO, WHILE, CATCH, CONDITIONAL_AND, CONDITIONAL_OR;
 	
 }

--- a/src/main/java/br/edu/ufba/softvis/visminer/metric/CCMetric.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/metric/CCMetric.java
@@ -70,6 +70,9 @@ public class CCMetric implements IMetric{
 			case FOR: cc += 1; break;
 			case DO: cc += 1; break;
 			case WHILE: cc += 1; break;
+			case CATCH: cc += 1; break;
+			case CONDITIONAL_OR: cc += 1; break;
+			case CONDITIONAL_AND: cc += 1; break;
 			}
 		}
 

--- a/src/main/java/br/edu/ufba/softvis/visminer/visitor/MethodVisitor.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/visitor/MethodVisitor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.DoStatement;
+import org.eclipse.jdt.core.dom.EnhancedForStatement;
 import org.eclipse.jdt.core.dom.ForStatement;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
@@ -22,6 +23,13 @@ public class MethodVisitor extends ASTVisitor {
 	private List<Statement> statements=new ArrayList<Statement>();	
 	
 	public boolean visit(ForStatement node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.FOR);
+		statements.add(statement);
+		return super.visit(node);
+	}
+	
+	public boolean visit(EnhancedForStatement node){
 		Statement statement = new Statement();
 		statement.setNodeType(NodeType.FOR);
 		statements.add(statement);

--- a/src/main/java/br/edu/ufba/softvis/visminer/visitor/MethodVisitor.java
+++ b/src/main/java/br/edu/ufba/softvis/visminer/visitor/MethodVisitor.java
@@ -1,0 +1,90 @@
+package br.edu.ufba.softvis.visminer.visitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CatchClause;
+import org.eclipse.jdt.core.dom.DoStatement;
+import org.eclipse.jdt.core.dom.ForStatement;
+import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.InfixExpression.Operator;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SwitchCase;
+import org.eclipse.jdt.core.dom.WhileStatement;
+
+import br.edu.ufba.softvis.visminer.ast.Statement;
+import br.edu.ufba.softvis.visminer.constant.NodeType;
+
+public class MethodVisitor extends ASTVisitor {
+
+	private List<Statement> statements=new ArrayList<Statement>();	
+	
+	public boolean visit(ForStatement node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.FOR);
+		statements.add(statement);
+		return super.visit(node);
+	}
+	
+	public boolean visit(WhileStatement node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.WHILE);
+		statements.add(statement);
+		return super.visit(node);
+	}
+	
+	public boolean visit(DoStatement node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.DO);
+		statements.add(statement);
+		return super.visit(node);
+	}
+	
+	public boolean visit(SwitchCase node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.SWITCH_CASE);
+		statements.add(statement);
+		return super.visit(node);
+	}
+	
+	public boolean visit(IfStatement node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.IF);
+		statements.add(statement);
+		return super.visit(node);
+	}
+	
+	public boolean visit(CatchClause node){
+		Statement statement = new Statement();
+		statement.setNodeType(NodeType.CATCH);
+		statements.add(statement);
+		return super.visit(node);
+	}	
+	
+	public boolean visit(InfixExpression node){
+		Statement statement = new Statement();
+		if(node.getOperator()==Operator.CONDITIONAL_AND){
+			statement.setNodeType(NodeType.CONDITIONAL_AND);
+			statements.add(statement);
+		}else if(node.getOperator()==Operator.CONDITIONAL_OR){
+			statement.setNodeType(NodeType.CONDITIONAL_OR);
+			statements.add(statement);
+		}	
+		return super.visit(node);
+	}
+	
+	
+	@Override
+	public void endVisit(MethodInvocation node) {
+		
+		super.endVisit(node);
+
+	}	
+
+	public List<Statement> getStatements() {
+		return statements;
+	}
+	
+}


### PR DESCRIPTION
In the first commit, I added 2 new fields, modifier and isConstructor, into MethodDeclaration and I refactored the processType method, creating a new method processMethod. In the second commit, I created the MethodVisitor to process nested statements. All the work that was being done by the processBlock method will be done by the MethodVisitor instead. Also, MethodVisitor is detecting "new" statements, such as catch, conditional_or and conditional_and, to be used to calculate CC metric. In the third commit, MethodVisitor detect EnhancedForStatement and some modifications in the CC metric processing.